### PR TITLE
remove vigilcode blog dead link

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,11 +248,6 @@
 										PiVPN - Create your own VPN for your home network
 									</a>
 								</li>
-								<li>
-									<a href="https://blog.vigilcode.com/2016/04/pivpn-easiest-quickest-setup-of-openvpn/">
-										PiVPN, Easiest &amp; Quickest Setup of OpenVPN
-									</a>
-								</li>
 							</ul>
 							<b>Video Guides</b>
 							<ul>


### PR DESCRIPTION
The vigilcode blog [dead link](https://blog.vigilcode.com/2016/04/pivpn-easiest-quickest-setup-of-openvpn/) in article/blog section has been removed.